### PR TITLE
Fixed loading config file from JAR

### DIFF
--- a/src/main/java/org/configureme/sources/FileLoader.java
+++ b/src/main/java/org/configureme/sources/FileLoader.java
@@ -77,7 +77,7 @@ public class FileLoader implements SourceLoader{
 			log.info("load configuration from file: " + f.getAbsolutePath());
 		try{
 			if (!f.exists())
-				return getContentFromJar(f.getName());
+				return getContentFromJar(getFileName(key));
 			
 			return IOUtils.readFileBufferedAsString(f, "UTF-8");
 		}catch(final IOException e){


### PR DESCRIPTION
There is a problem, if you want to load a file inside a directory, e.g. **distributeme/rights-routing**

The current loader would ignore the directory completly.